### PR TITLE
fixed after tests

### DIFF
--- a/hw_2/src/modules/blogs/application/blogs.service.ts
+++ b/hw_2/src/modules/blogs/application/blogs.service.ts
@@ -17,7 +17,14 @@ export const blogsService = {
     },
 
     async createBlog(blog: TBlog): Promise<WithId<TBlog>> {
-        return await blogsRepository.createBlog(blog);
+        const insertedId = await blogsRepository.createBlog(blog);
+
+        return {
+            ...blog, 
+            _id: insertedId,
+            createdAt: blog.createdAt ?? new Date().toISOString(),
+            isMembership: blog.isMembership ?? true,
+        };
     },
 
     async updateBlogById(id: string, blog: TBlogDTO): Promise<WithId<TBlog> | null> {

--- a/hw_2/src/modules/blogs/repositories/blogs.repository.ts
+++ b/hw_2/src/modules/blogs/repositories/blogs.repository.ts
@@ -39,10 +39,10 @@ export const blogsRepository = {
         return await blogsCollection.findOne({ _id: new ObjectId(id) });
     },
 
-    createBlog: async (blog: TBlog): Promise<WithId<TBlog>> => {
+    createBlog: async (blog: TBlog): Promise<ObjectId> => {
         const newBlog = await blogsCollection.insertOne(blog);
 
-        return { ...blog, _id: newBlog.insertedId};
+        return newBlog.insertedId;
     },
 
     updateBlogById: async (id: string, blog: TBlogDTO): Promise<WithId<TBlog> | null> => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Repository createBlog now returns the insertedId; service createBlog builds the returned blog with _id and default createdAt/isMembership.
> 
> - **Backend — Blogs**:
>   - **Repository (`blogs.repository.ts`)**: `createBlog` now returns `ObjectId` (`insertedId`) instead of `WithId<TBlog>`.
>   - **Service (`blogs.service.ts`)**: `createBlog` constructs and returns the blog using `insertedId`, setting defaults for `createdAt` and `isMembership`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 224e55ee0105e73d6d8ab8fc7011d2a0fa8c667d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->