### PR TITLE
fixed after tests

### DIFF
--- a/hw_2/src/modules/blogs/application/blogs.service.ts
+++ b/hw_2/src/modules/blogs/application/blogs.service.ts
@@ -23,7 +23,7 @@ export const blogsService = {
             ...blog, 
             _id: insertedId,
             createdAt: blog.createdAt ?? new Date().toISOString(),
-            isMembership: blog.isMembership ?? true,
+            isMembership: blog.isMembership ?? false,
         };
     },
 

--- a/hw_2/src/modules/blogs/repositories/blogs.repository.ts
+++ b/hw_2/src/modules/blogs/repositories/blogs.repository.ts
@@ -20,9 +20,11 @@ export const blogsRepository = {
             filter.name = { $regex: searchNameTerm, $options: 'i' };
         }
 
+        const sortDirectionValue = sortDirection === 'asc' ? 1 : -1;
+
         const items = await blogsCollection
             .find(filter)
-            .sort({ [sortBy]: sortDirection })
+            .sort({ [sortBy]: sortDirectionValue })
             .skip(skip)
             .limit(pageSize)
             .toArray();

--- a/hw_2/src/modules/blogs/routers/blogs.router.ts
+++ b/hw_2/src/modules/blogs/routers/blogs.router.ts
@@ -7,11 +7,12 @@ import { idValidation } from "../../../middlewares/validation/id-validators.midd
 import { paginationAndSortingValidation } from "../../../middlewares/validation/pagination-sorting-validation.middleware";
 import { BlogsSortBy } from "../constants";
 import { postsByBlogValidatorMiddleware } from "./middlewares/posts-by-blog-validators.middleware";
+import { PostsSortBy } from "../../posts/constants";
 
 export const blogsRouter = Router();
 
 blogsRouter
-    .get('/:id/posts', idValidation, errorsResultMiddleware, getPostsByBlogHandler)
+    .get('/:id/posts', idValidation, paginationAndSortingValidation(PostsSortBy), errorsResultMiddleware, getPostsByBlogHandler)
     .get('/:id', idValidation, errorsResultMiddleware, getBlogsByIdHandler)
     .get(
         '/',  

--- a/hw_2/src/modules/posts/repositories/posts.repository.ts
+++ b/hw_2/src/modules/posts/repositories/posts.repository.ts
@@ -22,9 +22,11 @@ export const postsRepository = {
             filter.blogId = blogId;
         }
 
+        const sortDirectionValue = sortDirection === 'asc' ? 1 : -1;
+
         const items = await postsCollection
             .find(filter)
-            .sort({ [sortBy]: sortDirection })
+            .sort({ [sortBy]: sortDirectionValue })
             .skip(skip)
             .limit(pageSize)
             .toArray();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fix sort direction mapping for Mongo queries, add pagination/sorting validation to blog posts endpoint, and default blog isMembership to false.
> 
> - **Blogs**:
>   - **Service**: Default `isMembership` to `false` in `createBlog`.
>   - **Router**: Add `paginationAndSortingValidation(PostsSortBy)` to `GET /:id/posts`.
> - **Repositories**:
>   - **Blogs** and **Posts**: Map `sortDirection` to numeric values (`1`/`-1`) for MongoDB `.sort()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32a04bd0d18ce967aad42616594a0f5fca96a1d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->