### PR TITLE
fixed after test

### DIFF
--- a/hw_2/src/modules/blogs/application/blogs.service.ts
+++ b/hw_2/src/modules/blogs/application/blogs.service.ts
@@ -17,13 +17,17 @@ export const blogsService = {
     },
 
     async createBlog(blog: TBlog): Promise<WithId<TBlog>> {
-        const insertedId = await blogsRepository.createBlog(blog);
+        const newBlog: TBlog = {
+            ...blog,
+            createdAt: new Date().toISOString(),
+            isMembership: false,
+        };
+
+        const insertedId = await blogsRepository.createBlog(newBlog);
 
         return {
-            ...blog, 
+            ...newBlog, 
             _id: insertedId,
-            createdAt: blog.createdAt ?? new Date().toISOString(),
-            isMembership: blog.isMembership ?? false,
         };
     },
 

--- a/hw_2/src/modules/blogs/routers/blogs.router.ts
+++ b/hw_2/src/modules/blogs/routers/blogs.router.ts
@@ -12,7 +12,13 @@ import { PostsSortBy } from "../../posts/constants";
 export const blogsRouter = Router();
 
 blogsRouter
-    .get('/:id/posts', idValidation, paginationAndSortingValidation(PostsSortBy), errorsResultMiddleware, getPostsByBlogHandler)
+    .get(
+        '/:id/posts', 
+        idValidation, 
+        paginationAndSortingValidation(PostsSortBy), 
+        errorsResultMiddleware, 
+        getPostsByBlogHandler
+    )
     .get('/:id', idValidation, errorsResultMiddleware, getBlogsByIdHandler)
     .get(
         '/',  

--- a/hw_2/src/modules/blogs/routers/handlers/get-blogs.handler.ts
+++ b/hw_2/src/modules/blogs/routers/handlers/get-blogs.handler.ts
@@ -17,7 +17,9 @@ export async function getBlogsHandler(req: Request<{}, {}, {}, Partial<TBlogQuer
             totalCount,
         });
 
-        res.send(blogsViewModel);
+        res
+            .status(HttpStatus.Ok)
+            .json(blogsViewModel);
     } catch (e: unknown) {
         res.sendStatus(HttpStatus.InternalServerError);
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Apply defaults for `createdAt` and `isMembership` when creating blogs and return a 200 JSON payload from the blogs list handler.
> 
> - **Blogs Service (`blogs.service.ts`)**:
>   - `createBlog` now constructs `newBlog` with defaults (`createdAt`, `isMembership: false`) before persisting and returns it with `_id`.
> - **Handlers (`get-blogs.handler.ts`)**:
>   - `getBlogsHandler` now responds with `status(200)` and `json(...)` instead of `send(...)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 184f51402cc3969bb0c4e8892c39766dc667bdd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->