### PR TITLE
feat: added users and login endpoints

### DIFF
--- a/hw_2/package.json
+++ b/hw_2/package.json
@@ -19,6 +19,7 @@
     "@types/swagger-ui-express": "^4.1.8",
     "@typescript-eslint/eslint-plugin": "^8.46.2",
     "@typescript-eslint/parser": "^8.46.2",
+    "argon2": "^0.44.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "eslint": "^9.38.0",

--- a/hw_2/readme.md
+++ b/hw_2/readme.md
@@ -18,3 +18,7 @@ get, put, delete: /api/posts/:id
 get, post: /api/blogs/
 get, put, delete: /api/blogs/:id
 get, post: api/blogs/:id/posts
+
+TODO:
+перевести все на cqrs 
+object result добавить везде

--- a/hw_2/src/core/settings/settings.ts
+++ b/hw_2/src/core/settings/settings.ts
@@ -7,6 +7,8 @@ export const SETTINGS = {
         BLOGS: '/api/blogs',
         POSTS: '/api/posts',
         TESTING: '/api/testing',
+        USERS: '/api/users',
+        AUTH: '/api/auth',
     },
     ADMIN: process.env.ADMIN || 'admin:qwerty' || 'admin\qwerty',
     MONGO_URL: process.env.MONGO_URL,

--- a/hw_2/src/core/types/resultStasuses.ts
+++ b/hw_2/src/core/types/resultStasuses.ts
@@ -1,0 +1,7 @@
+export enum Statuses {
+    Success = 'Success',
+    NotFound = 'NotFound',
+    Forbidden = 'Forbidden',
+    Unauthorized = 'Unauthorized',
+    BadRequest = 'BadRequest'
+}

--- a/hw_2/src/core/types/resultTypes.ts
+++ b/hw_2/src/core/types/resultTypes.ts
@@ -1,0 +1,13 @@
+import { Statuses } from "./resultStasuses";
+
+type ExtensionType = {
+  field: string | null;
+  message: string;
+};
+
+export type Result<T = null> = {
+  status: Statuses;
+  errorMessage?: string;
+  extensions: ExtensionType[];
+  data: T;
+};

--- a/hw_2/src/db/db.ts
+++ b/hw_2/src/db/db.ts
@@ -2,15 +2,18 @@ import { Collection, Db, MongoClient } from "mongodb";
 import { SETTINGS } from '../core/settings/settings';
 import { TBlog } from "../modules/blogs/types/blog";
 import { TPost } from "../modules/posts/types/post";
+import { TUser } from "../modules/users/types/user";
 
 const MONGO_URL = SETTINGS.MONGO_URL;
 const MONGODB_NAME = SETTINGS.MONGODB_NAME;
 const BLOGS_COLLECTION_NAME = 'blogs';
 const POSTS_COLLECTION_NAME = 'posts';
+const USERS_COLLECTION_NAME = 'users';
 
 export let client: MongoClient;
 export let blogsCollection: Collection<TBlog>;
 export let postsCollection: Collection<TPost>;
+export let usersCollection: Collection<TUser>;
 
 export const runDB = async () => {
     if(!MONGO_URL) {
@@ -25,6 +28,7 @@ export const runDB = async () => {
 
     blogsCollection = db.collection<TBlog>(BLOGS_COLLECTION_NAME);
     postsCollection = db.collection<TPost>(POSTS_COLLECTION_NAME);
+    usersCollection = db.collection<TUser>(USERS_COLLECTION_NAME);
 
     try {
         await client.connect();

--- a/hw_2/src/modules/auth/application/argon2.service.ts
+++ b/hw_2/src/modules/auth/application/argon2.service.ts
@@ -1,0 +1,11 @@
+import argon2 from 'argon2';
+
+export const argon2Service = {
+    async generateHash(password: string) {
+        return await argon2.hash(password);
+    },
+
+    async checkPassword(password: string, hash: string) {
+        return await argon2.verify(hash, password);
+    }
+}

--- a/hw_2/src/modules/auth/application/auth.service.ts
+++ b/hw_2/src/modules/auth/application/auth.service.ts
@@ -1,0 +1,38 @@
+import { argon2Service } from './argon2.service';
+import { Result } from "../../../core/types/resultTypes";
+import { Statuses } from "../../../core/types/resultStasuses";
+import { usersQueryRepository } from "../../../modules/users/repositories/users.query-repository";
+import { WithId } from "mongodb";
+import { TUser } from "../../../modules/users/types/user";
+
+export const authService = {
+    loginUser: async (loginOrEmail: string, password: string): Promise<Result<WithId<TUser> | null>> => {
+        const user = await usersQueryRepository.findByLoginOrEmail(loginOrEmail);
+
+        if(!user) {
+            return {
+                status: Statuses.NotFound,
+                data: null,
+                errorMessage: 'Not Found',
+                extensions: [{ field: 'loginOrEmail', message: 'Not Found' }],
+            };
+        }
+
+        const isPasswordCorrect = await argon2Service.checkPassword(password, user.password);
+
+        if(!isPasswordCorrect) {
+            return {
+                status: Statuses.NotFound,
+                data: null,
+                errorMessage: 'Wrong password',
+                extensions: [{ field: 'password', message: 'Wrong password' }],
+            };
+        }
+
+        return {
+            status: Statuses.Success,
+            data: user,
+            extensions: [],
+        };
+    }
+}

--- a/hw_2/src/modules/auth/routers/auth.router.ts
+++ b/hw_2/src/modules/auth/routers/auth.router.ts
@@ -1,0 +1,18 @@
+/**
+ * Аутентификация с токеном для работы с данными users (login, logout)
+ */
+
+import { Router } from "express";
+import { errorsResultMiddleware } from "../../../middlewares/validation/errors-result.middleware";
+import { loginValidatorMiddleware } from "./middlewares/login-validators.middleware";
+import { loginHandler } from "./handlers";
+
+export const authRouter = Router();
+
+authRouter
+    .post(
+        '/login',
+        ...loginValidatorMiddleware,
+        errorsResultMiddleware,
+        loginHandler
+    )

--- a/hw_2/src/modules/auth/routers/handlers/index.ts
+++ b/hw_2/src/modules/auth/routers/handlers/index.ts
@@ -1,0 +1,1 @@
+export * from './login.handler';

--- a/hw_2/src/modules/auth/routers/handlers/login.handler.ts
+++ b/hw_2/src/modules/auth/routers/handlers/login.handler.ts
@@ -1,0 +1,26 @@
+import { Request, Response } from 'express';
+import { HttpStatus } from '../../../../core/types/httpStatuses';
+import { Statuses } from '../../../../core/types/resultStasuses';
+import { authService } from '../../application/auth.service';
+
+export async function loginHandler(req: Request, res: Response) {
+    try {
+        const { loginOrEmail, password } = req.body;
+
+        const result = await authService.loginUser(loginOrEmail, password);
+
+        if (result.status !== Statuses.Success) {
+            res
+                .status(HttpStatus.Unauthorized)
+                .send(result.extensions);
+            return;
+        }
+
+        res
+            .sendStatus(HttpStatus.NoContent);
+            
+    } catch (e: unknown) {
+        res.sendStatus(HttpStatus.InternalServerError);
+    }
+    
+}

--- a/hw_2/src/modules/auth/routers/middlewares/login-validators.middleware.ts
+++ b/hw_2/src/modules/auth/routers/middlewares/login-validators.middleware.ts
@@ -1,0 +1,22 @@
+import { body } from "express-validator";
+
+export const loginOrEmailValidator = body('loginOrEmail')
+    .isString()
+    .withMessage('loginOrEmail should be string')
+    .trim()
+    .notEmpty()
+    .withMessage('loginOrEmail shouldnt be empty')
+
+export const passwordValidator = body('password')
+    .isString()
+    .withMessage('password should be string')
+    .trim()
+    .notEmpty()
+    .withMessage('password shouldnt be empty')
+    .isLength({min: 6, max: 20})
+    .withMessage('Count of symbols for Password sould be between 6 and 20')
+
+export const loginValidatorMiddleware = [
+    loginOrEmailValidator,
+    passwordValidator,
+];

--- a/hw_2/src/modules/index.ts
+++ b/hw_2/src/modules/index.ts
@@ -1,4 +1,6 @@
 //Routers
 export * from './blogs/routers/blogs.router';
 export * from './posts/routers/posts.router';
+export * from './users/routers/users.router';
 export * from './testing/routers/testing.router';
+export * from './auth/routers/auth.router';

--- a/hw_2/src/modules/users/application/users.service.ts
+++ b/hw_2/src/modules/users/application/users.service.ts
@@ -1,0 +1,37 @@
+import { DeleteResult, ObjectId, WithId } from "mongodb";
+import { TUser } from "../types/user";
+import { TUserDTO } from "../repositories/dto/users-input.dto";
+import { usersQueryRepository } from "../repositories/users.query-repository";
+import { usersRepository } from "../repositories/user.repository";
+import { argon2Service } from "../../auth/application/argon2.service";
+
+export const usersService = {
+    createUser: async (inputUser: TUserDTO): Promise<{ user: WithId<TUser> | null }> => {
+        const passwordHash = await argon2Service.generateHash(inputUser.password);
+
+        const newUser: TUser = {
+            login: inputUser.login,
+            email: inputUser.email,
+            password: passwordHash,
+            createdAt: new Date().toISOString(),
+        };
+
+        const { insertedId } = await usersRepository.createUser(newUser);
+
+        return await usersQueryRepository.getUserById(insertedId);
+    },
+
+    deleteUser: async (id: string): Promise<string | null> => {
+        if(!ObjectId.isValid(id)) {
+            return Promise.resolve(null);
+        }
+
+        const deletedBlog = await usersRepository.deletedUser(id);
+
+        if (deletedBlog.deletedCount < 1) {
+            return null;
+        };
+
+        return id;
+    }
+}

--- a/hw_2/src/modules/users/constants.ts
+++ b/hw_2/src/modules/users/constants.ts
@@ -1,0 +1,5 @@
+export enum UsersSortBy {
+    CREATED_AT = 'createdAt',
+    LOGIN = 'login',
+    EMAIL = 'email'
+};

--- a/hw_2/src/modules/users/repositories/dto/users-input.dto.ts
+++ b/hw_2/src/modules/users/repositories/dto/users-input.dto.ts
@@ -1,0 +1,5 @@
+export type TUserDTO = {
+    login: string,
+    password: string,
+    email: string,
+}

--- a/hw_2/src/modules/users/repositories/user.repository.ts
+++ b/hw_2/src/modules/users/repositories/user.repository.ts
@@ -1,0 +1,13 @@
+import { usersCollection } from "../../../db/db";
+import { DeleteResult, ObjectId } from "mongodb";
+import { TUser } from "../types/user";
+
+export const usersRepository = {
+    createUser: async (newUser: TUser): Promise<{ insertedId: ObjectId }> => ({
+        insertedId: (await usersCollection.insertOne(newUser)).insertedId
+    }),
+
+    deletedUser: async (id: string): Promise<DeleteResult> => {
+        return await usersCollection.deleteOne({_id: new ObjectId(id)})
+    }
+}

--- a/hw_2/src/modules/users/repositories/users.query-repository.ts
+++ b/hw_2/src/modules/users/repositories/users.query-repository.ts
@@ -1,0 +1,58 @@
+import { ObjectId, WithId } from "mongodb";
+import { TUser, TUserQueryInput } from "../types/user";
+import { usersCollection } from "../../../db/db";
+
+
+export const usersQueryRepository = {
+    getUsers: async (queryDto: TUserQueryInput): Promise<{ items: WithId<TUser>[]; totalCount: number }> => {
+        const {
+            pageNumber,
+            pageSize,
+            sortBy,
+            sortDirection,
+            searchLoginTerm,
+            searchEmailTerm,
+        } = queryDto;
+
+        const skip = (pageNumber - 1) * pageSize;
+        const filter: any = {};
+
+        if (searchLoginTerm) {
+            filter.login = { $regex: searchLoginTerm, $options: 'i' };
+        }
+
+        if (searchEmailTerm) {
+            filter.email = { $regex: searchEmailTerm, $options: 'i' };
+        }
+
+        const sortDirectionValue = sortDirection === 'asc' ? 1 : -1;
+
+        const items = await usersCollection
+            .find(filter)
+            .sort({ [sortBy]: sortDirectionValue })
+            .skip(skip)
+            .limit(pageSize)
+            .toArray();
+
+        const totalCount = await usersCollection.countDocuments(filter);
+
+        return {
+            items,
+            totalCount,
+        }
+    },
+
+    checkFieldTaken: async (field: string): Promise<WithId<TUser> | null> => {
+        return await usersCollection.findOne({ [field]: field })
+    },
+
+    getUserById: async (id: string | ObjectId): Promise<{ user: WithId<TUser> | null }> => ({
+        user: await usersCollection.findOne({ _id: new ObjectId(id) })
+    }),
+
+    findByLoginOrEmail: async (loginOrEmail: string): Promise<WithId<TUser> | null> => {
+        return await usersCollection.findOne({
+          $or: [{ email: loginOrEmail }, { login: loginOrEmail }],
+        });
+      },
+}

--- a/hw_2/src/modules/users/routers/handlers/create-user.handler.ts
+++ b/hw_2/src/modules/users/routers/handlers/create-user.handler.ts
@@ -1,0 +1,27 @@
+import { Request, Response } from 'express';
+import { HttpStatus } from '../../../../core/types/httpStatuses';
+import { TUserDTO } from '../../repositories/dto/users-input.dto';
+import { usersService } from '../../application/users.service';
+import { mapToUsersViewModel } from '../mappers/map-to-users-view-model.util';
+
+export async function createUserHandler(req: Request<{}, {}, TUserDTO>, res: Response) {
+    try {
+        const { user } = await usersService.createUser(req.body);
+
+        if(!user) {
+            res
+                .status(HttpStatus.NotFound)
+                .send(`User was not created`);
+
+            return;
+        }
+
+        const newUserViewModel = mapToUsersViewModel(user);
+
+        res
+            .status(HttpStatus.Created)
+            .json(newUserViewModel)
+    } catch(error: unknown) {
+        res.sendStatus(HttpStatus.InternalServerError);
+    }
+}

--- a/hw_2/src/modules/users/routers/handlers/delete-user.handler.ts
+++ b/hw_2/src/modules/users/routers/handlers/delete-user.handler.ts
@@ -1,0 +1,24 @@
+import { Request, Response } from 'express';
+import { usersService } from '../../application/users.service';
+import { HttpStatus } from '../../../../core/types/httpStatuses';
+
+export async function deleteUserHandler(req: Request, res: Response) {
+    try {
+        const deletedUserId = await usersService.deleteUser(req.params.id);
+
+        if(deletedUserId === null) {
+            res
+                .status(HttpStatus.NotFound)
+                .send(`User for passed id ${req.params.id} doesn\'t exist`);
+
+            return;
+        }
+
+        res
+            .status(HttpStatus.NoContent)
+            .send('Deleted!')
+
+    } catch(e: unknown) {
+        res.sendStatus(HttpStatus.InternalServerError);
+    }
+}

--- a/hw_2/src/modules/users/routers/handlers/get-users.handler.ts
+++ b/hw_2/src/modules/users/routers/handlers/get-users.handler.ts
@@ -1,0 +1,26 @@
+import { Request, Response } from 'express';
+import { TUserQueryInput } from '../../types/user';
+import { HttpStatus } from '../../../../core/types/httpStatuses';
+import { setDefaultSortAndPaginationIfNotExist } from '../../../../core/helpers/set-default-sort-and-pagination';
+import { usersQueryRepository } from '../../repositories/users.query-repository';
+import { mapToUsersViewModelPaginated } from '../mappers/map-to-users-view-model-paginated.util';
+
+export async function getUsersHandler(req: Request<{}, {}, {}, Partial<TUserQueryInput>>, res: Response) {
+    try {
+        const queryInput: TUserQueryInput = setDefaultSortAndPaginationIfNotExist(req.query);
+
+        const { items, totalCount } = await usersQueryRepository.getUsers(queryInput);
+
+        const usersViewModel = mapToUsersViewModelPaginated(items, {
+            pageNumber: queryInput.pageNumber,
+            pageSize: queryInput.pageSize,
+            totalCount,
+        });
+
+        res
+            .status(HttpStatus.Ok)
+            .json(usersViewModel);
+    } catch (e: unknown) {
+        res.sendStatus(HttpStatus.InternalServerError);
+    }
+}

--- a/hw_2/src/modules/users/routers/handlers/index.ts
+++ b/hw_2/src/modules/users/routers/handlers/index.ts
@@ -1,0 +1,4 @@
+export * from './get-users.handler';
+export * from './create-user.handler';
+export * from './delete-user.handler';
+

--- a/hw_2/src/modules/users/routers/mappers/map-to-users-view-model-paginated.util.ts
+++ b/hw_2/src/modules/users/routers/mappers/map-to-users-view-model-paginated.util.ts
@@ -1,0 +1,28 @@
+import { WithId } from 'mongodb';
+import { TUser } from '../../types/user';
+import { TUserViewModel, TUserViewModelPaginated } from '../../types/user-view-model';
+
+type TMetaParams = {
+  pageNumber: number,
+  pageSize: number,
+  totalCount: number,
+}
+
+export function mapToUsersViewModelPaginated(
+    users: WithId<TUser>[], 
+    meta: TMetaParams,
+  ): TUserViewModelPaginated {
+  return {
+    pagesCount:	Math.ceil(meta.totalCount / meta.pageSize),
+    page: meta.pageNumber,
+    pageSize: meta.pageSize,
+    totalCount: meta.totalCount,
+    items: users.map(
+      (user): TUserViewModel => ({
+        id: user._id.toString(),
+        login: user.login,
+        email: user.email,
+        createdAt: user.createdAt,
+    })),
+  }
+}

--- a/hw_2/src/modules/users/routers/mappers/map-to-users-view-model.util.ts
+++ b/hw_2/src/modules/users/routers/mappers/map-to-users-view-model.util.ts
@@ -1,0 +1,12 @@
+import { WithId } from 'mongodb';
+import { TUser } from '../../types/user';
+import { TUserViewModel } from '../../types/user-view-model';
+
+export function mapToUsersViewModel(user: WithId<TUser>): TUserViewModel {
+  return {
+      id: user._id.toString(),
+      login: user.login,
+      email: user.email,
+      createdAt: user.createdAt,
+  }
+}

--- a/hw_2/src/modules/users/routers/middlewares/users-validators.middleware.ts
+++ b/hw_2/src/modules/users/routers/middlewares/users-validators.middleware.ts
@@ -1,0 +1,49 @@
+import { body } from "express-validator";
+import { usersQueryRepository } from "../../repositories/users.query-repository";
+
+export const userLoginValidator = body('login')
+    .isString()
+    .withMessage('Login should be string')
+    .trim()
+    .notEmpty()
+    .withMessage('Login shouldnt be empty')
+    .isLength({min: 3, max: 10})
+    .withMessage('Count of symbols for login sould be between 3 and 10')
+    .matches(/^[a-zA-Z0-9_-]*$/)
+    .withMessage('Login should include only symbols')
+    .custom(async (login) => {
+        const isLoginExist = await usersQueryRepository.checkFieldTaken(login);
+
+        if(isLoginExist) {
+            return Promise.reject('login already taken');
+        }
+    })
+
+export const userPasswordValidator = body('password')
+    .isString()
+    .withMessage('Password should be string')
+    .notEmpty()
+    .withMessage('Password shouldnt be empty')
+    .isLength({min: 6, max: 20})
+    .withMessage('Count of symbols for Password sould be between 6 and 20')
+
+export const userEmailValidator = body('email')
+    .isString()
+    .withMessage('Email should be string')
+    .notEmpty()
+    .withMessage('Email shouldnt be empty')
+    .matches(/^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/)
+    .withMessage('Email should looks like example@example.com')
+    .custom(async (email) => {
+        const isEmailExist = await usersQueryRepository.checkFieldTaken(email);
+
+        if(isEmailExist) {
+            return Promise.reject('Email already exist');
+        }
+    })
+
+export const usersValidatorMiddleware = [
+    userLoginValidator,
+    userPasswordValidator,
+    userEmailValidator,
+];

--- a/hw_2/src/modules/users/routers/users.router.ts
+++ b/hw_2/src/modules/users/routers/users.router.ts
@@ -1,0 +1,35 @@
+import { Router } from "express";
+import { paginationAndSortingValidation } from "../../../middlewares/validation/pagination-sorting-validation.middleware";
+import { UsersSortBy } from "../constants";
+import { errorsResultMiddleware } from "../../../middlewares/validation/errors-result.middleware";
+import { createUserHandler, deleteUserHandler, getUsersHandler } from "./handlers";
+import { authorizationMiddleware } from "../../../middlewares/auth/basic-auth-middleware";
+import { usersValidatorMiddleware } from "./middlewares/users-validators.middleware";
+import { idValidation } from "../../../middlewares/validation/id-validators.middleware";
+
+export const usersRouter = Router();
+
+usersRouter
+    .get(
+        '/',
+        authorizationMiddleware,
+        paginationAndSortingValidation(UsersSortBy),
+        errorsResultMiddleware,
+        getUsersHandler
+    )
+
+    .post(
+        '/',
+        authorizationMiddleware,
+        ...usersValidatorMiddleware,
+        errorsResultMiddleware,
+        createUserHandler
+    )
+
+    .delete(
+        '/:id',
+        authorizationMiddleware,
+        idValidation,
+        errorsResultMiddleware,
+        deleteUserHandler
+    )

--- a/hw_2/src/modules/users/types/user-view-model.ts
+++ b/hw_2/src/modules/users/types/user-view-model.ts
@@ -1,0 +1,14 @@
+export type TUserViewModel = {
+    id: string,
+    login: string,
+    email: string;
+    createdAt: string;
+}
+
+export type TUserViewModelPaginated = {
+    pagesCount?: number,
+    page?: number,
+    pageSize?: number,
+    totalCount?: number,
+    items: TUserViewModel[],
+}

--- a/hw_2/src/modules/users/types/user.ts
+++ b/hw_2/src/modules/users/types/user.ts
@@ -1,0 +1,14 @@
+import { TPaginationAndSorting } from "../../../core/types/sortingPagination";
+import { UsersSortBy } from "../constants";
+
+export type TUser = {
+    login: string;
+    email: string;
+    password: string;
+    createdAt: string;
+}
+
+export type TUserQueryInput = TPaginationAndSorting<UsersSortBy> & {
+    searchLoginTerm?: string;
+    searchEmailTerm?: string;
+};;

--- a/hw_2/src/setup-app.ts
+++ b/hw_2/src/setup-app.ts
@@ -1,4 +1,4 @@
-import { blogsRouter, postsRouter, testingRouter } from './modules';
+import { authRouter, blogsRouter, postsRouter, testingRouter, usersRouter } from './modules';
 import { SETTINGS } from './core/settings/settings';
 import express, { Express } from 'express';
 import cors from 'cors';
@@ -12,6 +12,8 @@ export const setupApp = (app: Express) => {
   app.use(SETTINGS.PATH.BLOGS, blogsRouter);
   app.use(SETTINGS.PATH.POSTS, postsRouter);
   app.use(SETTINGS.PATH.TESTING, testingRouter);
+  app.use(SETTINGS.PATH.USERS, usersRouter);
+  app.use(SETTINGS.PATH.AUTH, authRouter);
 
   setupSwagger(app);
 

--- a/hw_2/yarn.lock
+++ b/hw_2/yarn.lock
@@ -312,6 +312,11 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@epic-web/invariant@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@epic-web/invariant/-/invariant-1.0.0.tgz#1073e5dee6dd540410784990eb73e4acd25c9813"
+  integrity sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==
+
 "@eslint-community/eslint-utils@^4.7.0", "@eslint-community/eslint-utils@^4.8.0":
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz#7308df158e064f0dd8b8fdb58aa14fa2a7f913b3"
@@ -683,6 +688,11 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@phc/format@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@phc/format/-/format-1.0.0.tgz#b5627003b3216dc4362125b13f48a4daa76680e4"
+  integrity sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==
 
 "@pkgr/core@^0.2.9":
   version "0.2.9"
@@ -1150,6 +1160,16 @@ arg@^4.1.0:
   resolved "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
+argon2@^0.44.0:
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/argon2/-/argon2-0.44.0.tgz#65a5ba662bba66af41407aa0457decf4af101742"
+  integrity sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==
+  dependencies:
+    "@phc/format" "^1.0.0"
+    cross-env "^10.0.0"
+    node-addon-api "^8.5.0"
+    node-gyp-build "^4.8.4"
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz"
@@ -1541,6 +1561,14 @@ create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
+cross-env@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-10.1.0.tgz#cfd2a6200df9ed75bfb9cb3d7ce609c13ea21783"
+  integrity sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==
+  dependencies:
+    "@epic-web/invariant" "^1.0.0"
+    cross-spawn "^7.0.6"
 
 cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
@@ -3043,6 +3071,16 @@ negotiator@0.6.3:
   version "0.6.3"
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
+
+node-addon-api@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-8.5.0.tgz#c91b2d7682fa457d2e1c388150f0dff9aafb8f3f"
+  integrity sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==
+
+node-gyp-build@^4.8.4:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.4.tgz#8a70ee85464ae52327772a90d66c6077a900cfc8"
+  integrity sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces users API (list/create/delete) with validation and password hashing, plus an auth login route, wired into DB, settings, and app routing.
> 
> - **Backend/API**:
>   - **Users**: Add `GET /api/users`, `POST /api/users`, `DELETE /api/users/:id` with basic auth, pagination/sorting validation, field validators, view mappers, repository (`users.repository`/`users.query-repository`), and service hashing passwords via `argon2`.
>   - **Auth**: Add `POST /api/auth/login` with validators and handler using `authService` to verify credentials (204 on success, 401 with errors otherwise).
> - **Core/DB**:
>   - Wire `users` collection in `db.ts`; add paths `SETTINGS.PATH.USERS` and `SETTINGS.PATH.AUTH`; mount `usersRouter` and `authRouter` in `setup-app`.
>   - Add result types: `Statuses` enum and generic `Result<T>`.
> - **Dependencies**:
>   - Install `argon2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ad53efca72f08afb11e87b8c295cd26e6fad72e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->