### PR TITLE
fix: delete all data for users

### DIFF
--- a/hw_2/src/modules/testing/routers/testing.router.ts
+++ b/hw_2/src/modules/testing/routers/testing.router.ts
@@ -1,5 +1,5 @@
 import { HttpStatus } from '../../../core/types/httpStatuses';
-import { blogsCollection, postsCollection } from '../../../db/db';
+import { blogsCollection, postsCollection, usersCollection } from '../../../db/db';
 import { Router, Request, Response } from "express";
 
 export const testingRouter = Router();
@@ -9,6 +9,7 @@ testingRouter.delete('/all-data', async (_req: Request, res: Response) => {
     try {
       await blogsCollection.deleteMany({});
       await postsCollection.deleteMany({});
+      await usersCollection.deleteMany({});
   
       res
         .status(HttpStatus.NoContent)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extends the testing /all-data cleanup to also purge users in addition to blogs and posts.
> 
> - **Testing API**
>   - **`testing.router.ts`**:
>     - `/all-data` now deletes from `usersCollection` alongside `blogsCollection` and `postsCollection`.
>     - Adds import of `usersCollection` from `db/db`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52b7b4c0f9988aef0682d8e3be3b656db99c4580. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->