### PR TITLE
fix: getUsers if email and login

### DIFF
--- a/hw_2/src/modules/users/repositories/users.query-repository.ts
+++ b/hw_2/src/modules/users/repositories/users.query-repository.ts
@@ -17,11 +17,14 @@ export const usersQueryRepository = {
         const skip = (pageNumber - 1) * pageSize;
         const filter: any = {};
 
-        if (searchLoginTerm) {
+        if (searchLoginTerm && searchEmailTerm) {
+            filter.$or = [
+                { login: { $regex: searchLoginTerm, $options: 'i' } },
+                { email: { $regex: searchEmailTerm, $options: 'i' } }
+            ];
+        } else if (searchLoginTerm) {
             filter.login = { $regex: searchLoginTerm, $options: 'i' };
-        }
-
-        if (searchEmailTerm) {
+        } else if (searchEmailTerm) {
             filter.email = { $regex: searchEmailTerm, $options: 'i' };
         }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates getUsers to support combined login/email filtering with $or and mutually exclusive single-term filters.
> 
> - **Users Query Repository (`users.query-repository.ts`)**:
>   - Update `getUsers` filter logic:
>     - When both `searchLoginTerm` and `searchEmailTerm` are provided, use `$or` to match either `login` or `email`.
>     - Use `else if` branches to apply only one filter when a single term is provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 295d9f91b7c5536f3ab267c98f1c7a540207a21d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->